### PR TITLE
add `Into<T>` code generation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ A library to help you generate code that mapped one struct to another.
 
 # Example
 
+## Generate `From<T>`
+
 ```rust
 use structmapper::StructMapper;
 
@@ -46,4 +48,44 @@ let to = To::from((
 ));
 assert_eq!(to.base, 42);
 assert_eq!(to.value, 1 + 2 + 3);
+```
+
+## Generate `Into<T>`
+
+```rust
+use structmapper::StructMapper;
+
+struct Into1 {
+base: i32,
+value: i32,
+}
+
+struct Into2 {
+base: i32,
+value: i32,
+}
+
+struct Into3 {
+value: i32,
+}
+
+#[derive(StructMapper)]
+#[struct_mapper(into_type = "Into1")]
+#[struct_mapper(into_type = "Into2", fields(base = "Default::default()"))]
+#[struct_mapper(into_type = "Into3", ignore(base))]
+struct From {
+base: i32,
+value: i32,
+}
+
+let to: Into1 = From { base: 1111, value: 1 }.into();
+assert_eq!(to.base, 1111);
+assert_eq!(to.value, 1);
+
+let to: Into2 = From { base: 123, value: 1 }.into();
+assert_eq!(to.base, 0);
+assert_eq!(to.value, 1);
+
+let to: Into3 = From { base: 0, value: 2 }.into();
+assert_eq!(to.value, 2);
 ```

--- a/crates/structmapper-codegen/Cargo.toml
+++ b/crates/structmapper-codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "structmapper-codegen"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["Flux Xu <fluxxu@gmail.com>"]
 edition = "2018"
 description = "A library to help you generate code that mapped one struct to another."

--- a/crates/structmapper-test/src/lib.rs
+++ b/crates/structmapper-test/src/lib.rs
@@ -1,5 +1,5 @@
 #[test]
-fn test_derive() {
+fn test_from() {
   use structmapper::StructMapper;
 
   struct From1 {
@@ -82,4 +82,43 @@ fn test_field_override() {
   let to = To::from(From { a: 1, b: 2 });
   assert_eq!(to.a, 1234);
   assert_eq!(to.b, 2);
+}
+
+#[test]
+fn test_into() {
+  use structmapper::StructMapper;
+
+  struct Into1 {
+    base: i32,
+    value: i32,
+  }
+
+  struct Into2 {
+    base: i32,
+    value: i32,
+  }
+
+  struct Into3 {
+    value: i32,
+  }
+
+  #[derive(StructMapper)]
+  #[struct_mapper(into_type = "Into1")]
+  #[struct_mapper(into_type = "Into2", fields(base = "Default::default()"))]
+  #[struct_mapper(into_type = "Into3", ignore(base))]
+  struct From {
+    base: i32,
+    value: i32,
+  }
+
+  let to: Into1 = From { base: 1111, value: 1 }.into();
+  assert_eq!(to.base, 1111);
+  assert_eq!(to.value, 1);
+
+  let to: Into2 = From { base: 123, value: 1 }.into();
+  assert_eq!(to.base, 0);
+  assert_eq!(to.value, 1);
+
+  let to: Into3 = From { base: 0, value: 2 }.into();
+  assert_eq!(to.value, 2);
 }

--- a/crates/structmapper/Cargo.toml
+++ b/crates/structmapper/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "structmapper"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["Flux Xu <fluxxu@gmail.com>"]
 edition = "2018"
 description = "A library to help you generate code that mapped one struct to another."
 license = "MIT"
 repository = "https://github.com/BSpaceinc/structmapper.git"
+readme = "../../README.md"
 
 [dependencies]
-structmapper-codegen = "0.1"
+structmapper-codegen = "0.2"

--- a/crates/structmapper/src/lib.rs
+++ b/crates/structmapper/src/lib.rs
@@ -41,4 +41,10 @@
 //!   let to = To::from((From1 { value: 1 }, From2 { value: 2 }, From3 { value: 3 }));
 //!   assert_eq!(to.value, 1 + 2 + 3);
 //! ```
+
 pub use structmapper_codegen::StructMapper;
+
+/// A value-to-value conversion that consumes the input value. The opposite of From.
+pub trait MapInto<T> {
+  fn map_into(self) -> T;
+}


### PR DESCRIPTION
```rust
  use structmapper::StructMapper;

  struct Into1 {
    base: i32,
    value: i32,
  }

  struct Into2 {
    base: i32,
    value: i32,
  }

  struct Into3 {
    value: i32,
  }

  #[derive(StructMapper)]
  #[struct_mapper(into_type = "Into1")]
  #[struct_mapper(into_type = "Into2", fields(base = "Default::default()"))]
  #[struct_mapper(into_type = "Into3", ignore(base))]
  struct From {
    base: i32,
    value: i32,
  }

  let to: Into1 = From { base: 1111, value: 1 }.into();
  assert_eq!(to.base, 1111);
  assert_eq!(to.value, 1);

  let to: Into2 = From { base: 123, value: 1 }.into();
  assert_eq!(to.base, 0);
  assert_eq!(to.value, 1);

  let to: Into3 = From { base: 0, value: 2 }.into();
  assert_eq!(to.value, 2);
```